### PR TITLE
Vertically align file title in Sliding Panes

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -5667,6 +5667,10 @@ body.plugin-sliding-panes-rotate-header .workspace > .mod-root > .workspace-leaf
 body.plugin-sliding-panes-rotate-header .workspace > .mod-root > .workspace-leaf.mod-active > .workspace-leaf-content > .view-header > .view-header-title-container:after {
     background: none !important;
 }
+/* vertically align file title in sliding panes */
+body.plugin-sliding-panes-rotate-header.plugin-sliding-select-orientation-mixed .workspace > .mod-root > .workspace-leaf > .workspace-leaf-content > .view-header {
+    padding: 5px;
+}
 
 /*──────────────────────────────────────────────────────────────*/
 /* Templater


### PR DESCRIPTION
- extends Sliding Panes support by vertically aligning file titles and icons when rotated
- class `.view-header` with a padding of `5px` is used to align everything in the file title