### PR TITLE
fix kanban scale var typo

### DIFF
--- a/scss/plugins/_plugin-kanban.scss
+++ b/scss/plugins/_plugin-kanban.scss
@@ -114,7 +114,7 @@ body .kanban-plugin__drag-container > .kanban-plugin__item-wrapper > .kanban-plu
 
 body .kanban-plugin__markdown-preview-view {
 	font-family: var(--font-preview);
-	font-size: var(--font-size-00);
+	font-size: var(--font-scale-00);
 	line-height: 1.5em;
 	padding: unset;
 	width: unset;


### PR DESCRIPTION
This change corrects a typo on a var in the kanban plugin CSS that prevented the intended font scale from being applied to the plugin.