### PR TITLE
Make table font monospaced when composing a document

### DIFF
--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -25,13 +25,13 @@
 
 		.markdown-preview-view h1,
 		.cm-s-obsidian .cm-header-1,
-		.cm-s-obsidian .HyperMD-header-1 {font-size: var(--heading-1-mobile);}	
+		.cm-s-obsidian .HyperMD-header-1 {font-size: var(--heading-1-mobile);}
 		.markdown-preview-view h2,
 		.cm-s-obsidian .cm-header-2,
-		.cm-s-obsidian .HyperMD-header-2 {font-size: var(--heading-2-mobile);}	
+		.cm-s-obsidian .HyperMD-header-2 {font-size: var(--heading-2-mobile);}
 		.markdown-preview-view h3,
 		.cm-s-obsidian .cm-header-3,
-		.cm-s-obsidian .HyperMD-header-3 {font-size: var(--heading-3-mobile);}	
+		.cm-s-obsidian .HyperMD-header-3 {font-size: var(--heading-3-mobile);}
 		.markdown-preview-view h4,
 		.cm-s-obsidian .cm-header-4,
 		.cm-s-obsidian .HyperMD-header-4 {font-size: var(--heading-4-mobile);}
@@ -80,13 +80,16 @@ body {
 .cm-line, // live preview
 .markdown-source-view.mod-cm6 .cm-scroller,
 .markdown-source-view,
-.cm-s-obsidian,
-.HyperMD-table-2.HyperMD-table-row.cm-line { //tables
+.cm-s-obsidian {
 	font-variant-ligatures: common-ligatures;
 	font-optical-sizing: auto;
 	font-family: var(--font-editor);
 	line-height: var(--leading-4);
 	letter-spacing: var(--tracking-2);
+}
+
+.HyperMD-table-2.HyperMD-table-row.cm-line { //tables
+	font-family: var(--font-frontmatter);
 }
 
 .cm-s-obsidian { //edit/source mode
@@ -102,7 +105,7 @@ body {
 /*
 .CodeMirror-wrap .CodeMirror-line,
 .CodeMirror-wrap .CodeMirror-line-like {
-	word-wrap: break-word; // same as overflow-wrap:break-word 
+	word-wrap: break-word; // same as overflow-wrap:break-word
 	white-space: pre-wrap;
 	word-break: break-word;
 	hyphens: auto;
@@ -151,7 +154,7 @@ body {
 	--color-heading-5-bg: var(--color-heading-5-bg-l);
 	--color-heading-6-bg: var(--color-heading-6-bg-l);
 
-	--color-heading-1-l: rgb(8, 8, 8); 
+	--color-heading-1-l: rgb(8, 8, 8);
 	--color-heading-2-l: rgb(8, 8, 8);
 	--color-heading-3-l: rgb(8, 8, 8);
 	--color-heading-4-l: rgb(8, 8, 8);
@@ -253,7 +256,7 @@ body {
 }
 
 .theme-dark { //visual balance between light and dark mode heading weights
-	--heading-1-weight-d: calc(var(--heading-1-weight) - 100); 
+	--heading-1-weight-d: calc(var(--heading-1-weight) - 100);
 	--heading-2-weight-d: calc(var(--heading-2-weight) - 100);
 	--heading-3-weight-d: calc(var(--heading-3-weight) - 100);
 	--heading-4-weight-d: calc(var(--heading-4-weight) - 100);
@@ -287,7 +290,7 @@ body {
 	line-height: var(--leading-1);
 	font-weight: var(--heading-1-weight);
 	letter-spacing: var(--tracking-0);
-}	
+}
 .markdown-preview-view h2,
 .cm-s-obsidian .cm-header-2,
 .cm-s-obsidian .HyperMD-header-2 {
@@ -295,7 +298,7 @@ body {
 	line-height: var(--leading-1);
 	font-weight: var(--heading-2-weight);
 	letter-spacing: var(--tracking-0);
-}	
+}
 .markdown-preview-view h3,
 .cm-s-obsidian .cm-header-3,
 .cm-s-obsidian .HyperMD-header-3 {
@@ -303,7 +306,7 @@ body {
 	line-height: var(--leading-1);
 	font-weight: var(--heading-3-weight);
 	letter-spacing: var(--tracking-0);
-}	
+}
 .markdown-preview-view h4,
 .cm-s-obsidian .cm-header-4,
 .cm-s-obsidian .HyperMD-header-4 {
@@ -311,7 +314,7 @@ body {
 	line-height: var(--leading-1);
 	font-weight: var(--heading-4-weight);
 	letter-spacing: var(--tracking-0);
-}	
+}
 .markdown-preview-view h5,
 .cm-s-obsidian .cm-header-5,
 .cm-s-obsidian .HyperMD-header-5 {
@@ -320,7 +323,7 @@ body {
 	font-weight: var(--heading-5-weight);
 	letter-spacing: var(--tracking-0);
 	color:var(--text-normal);
-}	
+}
 .markdown-preview-view h6,
 .cm-s-obsidian .cm-header-6,
 .cm-s-obsidian .HyperMD-header-6 {
@@ -370,7 +373,7 @@ body {
 /* ────────────────────────── Contextual Typography ───────────────────────── */
 
 .markdown-preview-view {
-	
+
 	& div[data-tag-name="h1"] + div > hr { margin-top: calc( -1 * var(--heading-1)); margin-bottom: 0; }
 	& div[data-tag-name="h2"] + div > hr { margin-top: calc( -1 * var(--heading-2)); margin-bottom: 0;}
 	& div[data-tag-name="h3"] + div > hr { margin-top: calc( -1 * var(--heading-3)); margin-bottom: 0;}


### PR DESCRIPTION
I've open an issue for this, but it turns out was easier than I thought :)

### Before

![image](https://user-images.githubusercontent.com/24597/150107076-3391a441-74b6-4db1-9491-870ccd65b6ff.png)

### After

![CleanShot 2022-01-19 at 10 54 47](https://user-images.githubusercontent.com/24597/150107201-9fe1b701-60bd-40cc-9081-085ce2dea2a7.png)

Also, I hope you don't mind but my linter removed a bunch of empty trailing spaces on the code, but not format change at all :)

Fix #121 