### PR TITLE
Modifiable unresolved node color

### DIFF
--- a/scss/abstracts/_var.scss
+++ b/scss/abstracts/_var.scss
@@ -131,6 +131,7 @@
 	--color-fill-focused: rgb(235, 84, 108);
 	--color-fill-tag: rgb(64, 150, 147);
 	--color-fill-attachment: rgb(236, 193, 81);
+	--color-fill-unresolved: rgb(241, 81, 72);
 
 	--color-accent-l: 64 150 147;
 	--color-accent-d: 64 150 147;

--- a/scss/extensions/_footer.scss
+++ b/scss/extensions/_footer.scss
@@ -320,6 +320,12 @@ settings:
 		format: rgb
 		default: rgb(236, 193, 81)
 	-
+		id: color-fill-unresolved
+		title: Unresolved Node Color
+		type: variable-color
+		format: rgb
+		default: rgb(241, 81, 72)
+	-
 		id: typography
 		title: Typography
 		type: heading

--- a/scss/plugins-core/_graph.scss
+++ b/scss/plugins-core/_graph.scss
@@ -18,7 +18,7 @@
 			color: var(--color-pink);
 		}
 		&-unresolved {
-			color: var(--background-modifier-error);
+			color: var(--color-fill-unresolved);
 			opacity: 1;
 		}
 	}


### PR DESCRIPTION
For unresolved nodes/notes, the previous colour was 
--background-modifier-error, which looks  a lot like the colour of the focused
node (--color-fill-focused). This can be confusing if you have a lot of
unresolved nodes. See for example https://github.com/jdanielmourao/obsidian-sanctum/issues/86, you can see
in the graph view that many nodes look like they are the active one.

This PR makes the unresolved node colour modifiable in Style Settings.