### PR TITLE
Fixed aside nested callout appearance

### DIFF
--- a/src/scss/features/asides.scss
+++ b/src/scss/features/asides.scss
@@ -53,10 +53,10 @@ body {
 		border-radius: var(--callout-radius);
 	}
 
-	.callout-title {
+	&>.callout-title {
 		display: none;
 	}
-	.callout-content { 
+	&>.callout-content { 
 		padding: 0 ;
 
 		& > p {
@@ -65,6 +65,10 @@ body {
 			margin-block-end: 8px;
 		}
 	}
+  
+	.callout-content { 
+		padding: 0 0 0 12px;
+  }
 }
 
 .callout[data-callout-metadata~=right] {

--- a/theme.css
+++ b/theme.css
@@ -2697,16 +2697,19 @@ body {
 .callout[data-callout~=aside]:hover {
   border-radius: var(--callout-radius);
 }
-.callout[data-callout~=aside] .callout-title {
+.callout[data-callout~=aside] > .callout-title {
   display: none;
 }
-.callout[data-callout~=aside] .callout-content {
+.callout[data-callout~=aside] > .callout-content {
   padding: 0;
 }
-.callout[data-callout~=aside] .callout-content > p {
+.callout[data-callout~=aside] > .callout-content > p {
   margin-top: 0;
   margin-block-start: 4px;
   margin-block-end: 8px;
+}
+.callout[data-callout~=aside] .callout-content {
+  padding: 0 0 0 12px;
 }
 .callout[data-callout-metadata~=right] {
   float: right;


### PR DESCRIPTION
Fixes #217 by making nested callout titles visible again.

Also added a new condensed padding to the nested callouts since the `padding: 0` from the aside style was cascading.

I recompiled the `theme.css` to save commits, but feel free to undo that.

## Original
![image](https://user-images.githubusercontent.com/109556932/236609059-c9e8ac15-be5f-4e08-8ff1-d9ab5c0fe459.png)

## Fixed
![image](https://user-images.githubusercontent.com/109556932/236609121-6ea9da9f-9a2b-4c24-92ed-23a4161feeb3.png)
